### PR TITLE
Sever structure align fix for atomic operations.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -34,11 +34,12 @@ type Info struct {
 
 // Server is our main struct.
 type Server struct {
+	gcid     uint64
+	grid     uint64
 	mu       sync.Mutex
 	info     Info
 	infoJSON []byte
 	sl       *sublist.Sublist
-	gcid     uint64
 	opts     *Options
 	auth     Auth
 	trace    bool
@@ -54,7 +55,6 @@ type Server struct {
 	stats
 
 	routeListener net.Listener
-	grid          uint64
 	routeInfo     Info
 	routeInfoJSON []byte
 	rcQuit        chan bool

--- a/server/server.go
+++ b/server/server.go
@@ -34,8 +34,9 @@ type Info struct {
 
 // Server is our main struct.
 type Server struct {
-	gcid     uint64
-	grid     uint64
+	gcid uint64
+	grid uint64
+	stats
 	mu       sync.Mutex
 	info     Info
 	infoJSON []byte
@@ -52,7 +53,6 @@ type Server struct {
 	done     chan bool
 	start    time.Time
 	http     net.Listener
-	stats
 
 	routeListener net.Listener
 	routeInfo     Info


### PR DESCRIPTION
Hello,

Due to [this](http://golang.org/pkg/sync/atomic/#pkg-note-BUG) gnatsd crash on windows with 386 bit architecture as soon as first client connects. Reordering structure fields the way counters are 64bit aligned fixes the issue.

Related to #15 and #14