### PR TITLE
handle stderr stat() throwing an error on Windows

### DIFF
--- a/gnatsd.go
+++ b/gnatsd.go
@@ -135,8 +135,9 @@ func configureLogger(s *server.Server, opts *server.Options) {
 	} else {
 		colors := true
 		// Check to see if stderr is being redirected and if so turn off color
-		stat, _ := os.Stderr.Stat()
-		if (stat.Mode() & os.ModeCharDevice) == 0 {
+		// Also turn off colors if we're running on Windows where os.Stderr.Stat() returns an invalid handle-error
+		stat, err := os.Stderr.Stat()
+		if err != nil || (stat.Mode()&os.ModeCharDevice) == 0 {
 			colors = false
 		}
 		log = logger.NewStdLogger(opts.Logtime, opts.Debug, opts.Trace, colors, true)


### PR DESCRIPTION
This fixes issue #77, which was caused by the stderr redirect check, due to os.stderr.stat() failing on Windows. 

This is probably the quickest possible fix, happy to expand on it if it's deemed necessary. Figured that handling the possible error from file.stat is not that important anyway as before it was just discarded.